### PR TITLE
metricsender: Support sending sla metrics and juju-machine metrics.

### DIFF
--- a/apiserver/metricsender/metricsender.go
+++ b/apiserver/metricsender/metricsender.go
@@ -60,10 +60,6 @@ func handleResponse(mm *state.MetricsManager, st ModelBackend, response wireform
 // over the MetricSender interface in batches
 // no larger than batchSize.
 func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchSize int, transmitVendorMetrics bool) error {
-	slaCreds, err := st.SLACredential()
-	if err != nil {
-		return errors.Trace(err)
-	}
 	metricsManager, err := st.MetricsManager()
 	if err != nil {
 		return errors.Trace(err)
@@ -93,7 +89,7 @@ func SendMetrics(st ModelBackend, sender MetricSender, clock clock.Clock, batchS
 				heldBatches = append(heldBatches, m.UUID())
 				heldBatchUnits[m.Unit()] = true
 			} else {
-				wireData = append(wireData, ToWire(m, slaCreds))
+				wireData = append(wireData, ToWire(m))
 			}
 		}
 		response, err := sender.Send(wireData)
@@ -170,7 +166,7 @@ func DefaultMetricSender() MetricSender {
 
 // ToWire converts the state.MetricBatch into a type
 // that can be sent over the wire to the collector.
-func ToWire(mb *state.MetricBatch, SLACreds []byte) *wireformat.MetricBatch {
+func ToWire(mb *state.MetricBatch) *wireformat.MetricBatch {
 	metrics := make([]wireformat.Metric, len(mb.Metrics()))
 	for i, m := range mb.Metrics() {
 		metrics[i] = wireformat.Metric{
@@ -187,6 +183,6 @@ func ToWire(mb *state.MetricBatch, SLACreds []byte) *wireformat.MetricBatch {
 		Created:        mb.Created().UTC(),
 		Metrics:        metrics,
 		Credentials:    mb.Credentials(),
-		SLACredentials: SLACreds,
+		SLACredentials: mb.SLACredentials(),
 	}
 }

--- a/apiserver/metricsender/metricsender_test.go
+++ b/apiserver/metricsender/metricsender_test.go
@@ -49,7 +49,7 @@ func (s *MetricSenderSuite) SetUpTest(c *gc.C) {
 func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 	now := time.Now().Round(time.Second)
 	metric := s.Factory.MakeMetric(c, &factory.MetricParams{Unit: s.credUnit, Sent: false, Time: &now})
-	result := metricsender.ToWire(metric, []byte("sla creds"))
+	result := metricsender.ToWire(metric)
 	m := metric.Metrics()[0]
 	metrics := []wireformat.Metric{
 		{
@@ -66,7 +66,7 @@ func (s *MetricSenderSuite) TestToWire(c *gc.C) {
 		Created:        metric.Created().UTC(),
 		Metrics:        metrics,
 		Credentials:    metric.Credentials(),
-		SLACredentials: []byte("sla creds"),
+		SLACredentials: metric.SLACredentials(),
 	}
 	c.Assert(result, gc.DeepEquals, expected)
 }
@@ -94,6 +94,7 @@ func (s *MetricSenderSuite) TestSendMetrics(c *gc.C) {
 	c.Assert(sent2.Sent(), jc.IsTrue)
 }
 
+// TODO We should have a test in state as well
 func (s *MetricSenderSuite) TestSendMetricsWithSLA(c *gc.C) {
 	var sender testing.MockSender
 	now := time.Now()

--- a/apiserver/metricsender/stateinterface.go
+++ b/apiserver/metricsender/stateinterface.go
@@ -22,7 +22,6 @@ type MetricsSenderBackend interface {
 	SetMetricBatchesSent(batchUUIDs []string) error
 	CountOfUnsentMetrics() (int, error)
 	CountOfSentMetrics() (int, error)
-	SLACredential() ([]byte, error)
 }
 
 // ModelBackend contains additional methods that are used by the metrics sender.


### PR DESCRIPTION
Also: we're more sensible about saving the metrics in state with
slas.